### PR TITLE
Add support for command line arguments using picocli

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,27 +42,40 @@ Note that you cannot use both `CSVFiles` and `connectionURL` at the same time. F
 
 The directory `example` contains an example of a mapping and configuration file. The example assumes the MySQL database to be called `r2rml`, be running on `localhost` and accessible to the user `foo` with password `bar`. The configuration file looks as follows:
 
-```
+```properties
 connectionURL = jdbc:mysql://localhost/r2rml
 user = foo
 password = bar
 mappingFile = mapping.ttl
 outputFile = output.ttl
 format = TURTLE
-```   
+```
 
 The output, after passing the properties file as an argument to the R2RML processor, should look as follows:
 
-```
+```turtle
 <http://data.example.com/employee/7369>
         a                             <http://example.com/ns#Employee> ;
         <http://example.com/ns#name>  "SMITH" .
 ```
 
+## Run with command line arguments
+
+R2RML can be run with command line arguments similar to the configuration properties. 
+
+```bash
+$ java -jar r2rml.jar --connectionURL jdbc:mysql://localhost/r2rml \
+  --user foo --password bar \
+  --mappingFile mapping.ttl \
+  --outputFile output.ttl \
+  --format TURTLE
+```
+
 ## Function with R2RML-F
+
 This implementation of R2RML re-implemented the ideas presented in [1], allowing one to declare and use functions in ECMAScript as (Function Valued) TermMaps in the mapping. R2RML-F extends R2RML's vocabulary with predicates for declaring functions, function calls and parameter bindings. These are declared in the namespace [rrf](http://kdeg.scss.tcd.ie/ns/rrf/index.html).
 
-```
+```turtle
 @prefix rr: <http://www.w3.org/ns/r2rml#> .
 @prefix ex: <http://example.com/ns#> .
 @prefix rrf: <http://kdeg.scss.tcd.ie/ns/rrf#>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
 			<artifactId>h2</artifactId>
 			<version>1.4.193</version>
 		</dependency>
+		<dependency>
+			<groupId>info.picocli</groupId>
+			<artifactId>picocli</artifactId>
+			<version>3.1.0</version>
+		</dependency>
 	</dependencies>
 	<organization>
 		<name>Adapt Centre, Trinity College Dublin</name>

--- a/src/r2rml/Main.java
+++ b/src/r2rml/Main.java
@@ -18,6 +18,7 @@ import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 
 import r2rml.engine.Configuration;
+import r2rml.engine.CliOptions;
 import r2rml.engine.R2RMLException;
 import r2rml.engine.R2RMLProcessor;
 
@@ -33,11 +34,14 @@ public class Main {
 	public static void main(String[] args) {
 
 		try {
+			Configuration configuration = null;
 			if(args.length != 1) {
-				throw new R2RMLException("Only and exactly one config file needs to be passed as an argument", null);
+				// If more than 1 arguments, we load config from arguments using picocli
+				CliOptions cli = new CliOptions(args);
+				configuration = new Configuration(cli);
+			} else {
+				configuration = new Configuration(args[0]);
 			}
-
-			Configuration configuration = new Configuration(args[0]);
 
 			if(configuration.getConnectionURL() == null && configuration.getCSVFiles().size() == 0) {
 				throw new R2RMLException("A connection URL or CVS files are mandatory.", null);

--- a/src/r2rml/engine/CliOptions.java
+++ b/src/r2rml/engine/CliOptions.java
@@ -1,0 +1,55 @@
+package r2rml.engine;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(name = "r2rml")
+public class CliOptions {
+
+	@Option(names = {"-h", "--help" }, usageHelp = true, description = "Display a help message")
+	boolean help = false;
+
+	@Option(names = {"--connectionURL"}, description = "A JDBC connection URL to a database", required = true)
+	String connectionURL = null;
+
+	@Option(names= {"-u", "--user"}, description = "Username for the user connecting to the database")
+	String user = null;
+
+	@Option(names= {"-p", "--password"}, description = "Password for the user connecting to the database")
+	String password = null;
+
+	@Option(names= {"--mappingFile"}, description = "The R2RML mapping file", required = true)
+	String mappingFile = null;
+
+	@Option(names= {"-o", "--outputFile"}, description = "The output file", required = true)
+	String outputFile = null;
+
+	@Option(names = {"-f", "--format"}, description = "Format of the output files (default: TURTLE)" )
+	String format = "TURTLE";
+	
+	@Option(names = {"--filePerGraph"}, description = "Flag to write the different graphs in separate files (default: false)" )
+	boolean filePerGraph = false;
+
+	@Option(names = {"-b", "--baseIRI"}, description = "Used in resolving relative IRIs produced by the R2RML mapping" )
+	String baseIRI = null;
+	
+	@Option(names = {"--CSVFiles"}, description = "A list of paths to CSV files that are separated by semicolons (cannot be used with connectionURL)" )
+	String CSVFiles = null;
+
+
+	public CliOptions(String[] args) {
+		try {
+			CliOptions cliOptions = CommandLine.populateCommand(this, args);
+			if (cliOptions.help) {
+				new CommandLine(this).usage(System.out);
+				System.exit(0);
+			}
+		} catch (CommandLine.ParameterException pe) {
+			System.out.println(pe.getMessage());
+			new CommandLine(this).usage(System.out);
+			// System.out.println("  * required parameter");
+			System.exit(64);
+		}
+	}
+}

--- a/src/r2rml/engine/Configuration.java
+++ b/src/r2rml/engine/Configuration.java
@@ -57,6 +57,26 @@ public class Configuration {
 		}
 	}
 	
+	// Getting configuration from argument (picocli CliOptions)
+	public Configuration(CliOptions cli) throws R2RMLException {
+		connectionURL = cli.connectionURL;
+		user = cli.user;
+		password = cli.password;
+		mappingFile = cli.mappingFile;
+		outputFile = cli.outputFile;
+		format = cli.format;	// TURTLE default define in CliOptions
+		filePerGraph = cli.filePerGraph;
+		baseIRI = cli.baseIRI;
+		
+		String files = cli.CSVFiles;
+		if(files != null && !"".equals(files)) {
+			StringTokenizer tk = new StringTokenizer(files, ";");
+			while(tk.hasMoreTokens()) {
+				CSVFiles.add(tk.nextToken());
+			}
+		}
+	}
+	
 	public Configuration() {
 		
 	}


### PR DESCRIPTION
Running using a config file is still supported (we use picocli only when more than 1 argument are provided). 
Examples on how to run it with arguments have been added to the README
e.g.
```bash
java -jar r2rml.jar --connectionURL jdbc:mysql://localhost/r2rml \
  --user foo --password bar \
  --mappingFile mapping.ttl \
  --outputFile output.ttl \
  --format TURTLE
```