### PR TITLE
Fix jdbc service declaration not merged in fat-jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,9 @@
 									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<mainClass>r2rml.Main</mainClass>
 								</transformer>
+								<transformer 
+									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer">
+								</transformer>
 							</transformers>
 						</configuration>
 					</execution>


### PR DESCRIPTION
As mentioned in #5 the shade plugin does not merge the service declarations of all jdbc drivers. The jar file while containing all dependencies does not know how to handle other drivers besides jtds.